### PR TITLE
DM-42219: Use urljoin in get_service_url

### DIFF
--- a/src/lsst/rsp/utils.py
+++ b/src/lsst/rsp/utils.py
@@ -3,6 +3,7 @@
 import os
 from pathlib import Path
 from typing import Any, Optional, Union
+from urllib.parse import urljoin
 
 import pyvo
 import requests
@@ -54,9 +55,9 @@ def get_service_url(name: str, env_name: Optional[str] = None) -> str:
     if url:
         return url
 
-    fqdn = os.getenv("EXTERNAL_INSTANCE_URL") or ""
+    base = os.getenv("EXTERNAL_INSTANCE_URL") or ""
     path = os.getenv(f"{env_name}_ROUTE") or f"api/{name}"
-    return f"{fqdn}/{path}"
+    return urljoin(base, path)
 
 
 def get_pyvo_auth() -> Optional[pyvo.auth.authsession.AuthSession]:

--- a/tests/utils_test.py
+++ b/tests/utils_test.py
@@ -2,7 +2,14 @@
 
 from __future__ import annotations
 
+import os
+from collections.abc import Iterator
+from unittest.mock import patch
+
+import pytest
+
 from lsst.rsp import format_bytes
+from lsst.rsp.utils import get_service_url
 
 
 def test_format_bytes() -> None:
@@ -13,3 +20,19 @@ def test_format_bytes() -> None:
     assert format_bytes(1234567890) == "1.23 GB"
     assert format_bytes(1234567890000) == "1.23 TB"
     assert format_bytes(1234567890000000) == "1.23 PB"
+
+
+@pytest.fixture
+def url_env() -> Iterator[None]:
+    """Set up some temporary environment variables for service URL tests."""
+    env = {
+        "EXTERNAL_INSTANCE_URL": "https://test.example.com/",
+        "TAP_ROUTE": "/api/tap",
+    }
+    with patch.dict(os.environ, env):
+        yield
+
+
+def test_get_service_url(url_env: None) -> None:
+    """Ensure there are no doubled slashes."""
+    assert get_service_url("tap") == "https://test.example.com/api/tap"


### PR DESCRIPTION
The URLs returned by get_service_url contained a doubled slash if <service>_ROUTE began with a slash, causing all of the PyVO authentication configuration to also be set up with a doubled slash. PyVO sometimes canonicalizes URLs internally, which will remove the second slash, and then the authentication configuration didn't match. This showed up as a failure to authenticate async TAP requests.

Use urljoin to construct the service URL returned by get_service_url, which avoids this problem. The drawback of this approach is that if EXTERNAL_INSTANCE_URL contains a path component (not just a hostname with an optional trailing slash), it must end with a slash or the last part of the path component will be removed by urljoin following normal HTML link semantics.