### PR TITLE
tickets/DM-44278: create path to logging directory if needed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,17 @@ Find changes for the upcoming release in the project's [changelog.d directory](h
 
 <!-- scriv-insert-here -->
 
+<a id='changelog-0.5.3'></a>
+## 0.5.3 (2024-05-09)
+
+### New features
+
+- Add RSPClient, a configured HTTP client for services in the same RSP instance.
+
+### Bug fixes
+
+- If the path to the logging profile directory doesn't exist, create it.
+
 <a id='changelog-0.5.2'></a>
 ## 0.5.2 (2024-04-22)
 

--- a/changelog.d/20240505_121808_athornton.md
+++ b/changelog.d/20240505_121808_athornton.md
@@ -1,7 +1,0 @@
-<!-- Delete the sections that don't apply -->
-
-### New features
-
-- Add RSPClient, a configured HTTP client for services in the same RSP instance.
-
-

--- a/src/lsst/rsp/startup/services/labrunner.py
+++ b/src/lsst/rsp/startup/services/labrunner.py
@@ -333,6 +333,9 @@ class LabRunner:
                 )
                 copy = True
         if copy:
+            pdir = user_profile.parent
+            if not pdir:
+                pdir.mkdir(parents=True)
             user_profile.write_bytes(
                 (TOP_DIR_PATH / "jupyterlab" / "20-logging.py").read_bytes()
             )


### PR DESCRIPTION
New users will not be able to start a lab unless we make it possible for labrunner to create the path to where their logging profile should be.