### PR TITLE
Fix: logging config relative path changed in two-python model.

### DIFF
--- a/changelog.d/20240617_092012_athornton_fix_missing_logconfig.md
+++ b/changelog.d/20240617_092012_athornton_fix_missing_logconfig.md
@@ -1,0 +1,5 @@
+<!-- Delete the sections that don't apply -->
+
+### Bug fixes
+
+- In two-python model, relative location of logging source changed; accomodate either.

--- a/src/lsst/rsp/startup/services/labrunner.py
+++ b/src/lsst/rsp/startup/services/labrunner.py
@@ -339,9 +339,14 @@ class LabRunner:
             if not pdir.is_dir():
                 pdir.mkdir(parents=True)
             jl_path = get_jupyterlab_config_dir()
-            user_profile.write_bytes(
-                (jl_path / "etc" / "20-logging.py").read_bytes()
-            )
+            srcfile = jl_path / "etc" / "20-logging.py"
+            # Location changed with two-python container.  Try each.
+            if not srcfile.is_file():
+                srcfile = jl_path / "20-logging.py"
+            if not srcfile.is_file():
+                self._logger.warning("Could not find source user log profile.")
+                return
+            user_profile.write_bytes(srcfile.read_bytes())
 
     def _copy_dircolors(self) -> None:
         self._logger.debug("Copying dircolors if needed")


### PR DESCRIPTION
Old images would break if started with a clean user homedir, because the input logging file was not found where expected.