### PR TITLE
Decouple DAF_BUTLER_CACHE_DIRECTORY from TMPDIR

### DIFF
--- a/changelog.d/20240816_134946_athornton.md
+++ b/changelog.d/20240816_134946_athornton.md
@@ -1,0 +1,5 @@
+<!-- Delete the sections that don't apply -->
+
+### Other changes
+
+- Decouple `DAF_BUTLER_CACHE_DIRECTORY` from `TMPDIR`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -225,6 +225,12 @@ select = ["ALL"]
 "src/lsst/rsp/startup/**" = [
     "S606",    # Sometimes we really mean os.execve(), not subprocess.run()
 ]
+"src/lsst/rsp/startup/services/labrunner.py" = [
+    "S108",    # We really do mean explicitly `/tmp`
+]
+"tests/startup_test.py" = [
+    "S108",    # We really do mean explicitly `/tmp`
+]
 [tool.ruff.lint.isort]
 known-first-party = ["lsst.rsp", "tests"]
 split-on-trailing-comma = false

--- a/src/lsst/rsp/startup/services/labrunner.py
+++ b/src/lsst/rsp/startup/services/labrunner.py
@@ -144,6 +144,11 @@ class LabRunner:
         # created as a writable directory (or that it already exists
         # as a writable directory).  If it can be (or is), we return the
         # whole path, and if not, we return None.
+        #
+        # This will only be readable by the user; they can chmod() it if
+        # they want to share, but for TMPDIR and DAF_BUTLER_CACHE_DIRECTORY
+        # they probably should not.  The mode will not be reset if the
+        # directory already exists and is writeable
         if not SCRATCH_PATH.is_dir():
             self._logger.debug(
                 # Debug only: not having /scratch is reasonable.
@@ -156,7 +161,7 @@ class LabRunner:
             return None
         user_scratch_path = SCRATCH_PATH / user / path
         try:
-            user_scratch_path.mkdir(parents=True, exist_ok=True)
+            user_scratch_path.mkdir(parents=True, exist_ok=True, mode=0o700)
         except (OSError, FileExistsError) as exc:
             self._logger.warning(
                 f"Could not create directory at {user_scratch_path!s}: {exc}"


### PR DESCRIPTION
@dhirving has suggested that `/scratch` probably is the appropriate place for butler cache, and should not be tied to (size-limited) `$TMPDIR`