### PR TITLE
Pass in pyvo auth as a keyword arg in class initialization

### DIFF
--- a/changelog.d/20250123_171813_steliosvoutsinas_DM_48554.md
+++ b/changelog.d/20250123_171813_steliosvoutsinas_DM_48554.md
@@ -1,0 +1,5 @@
+<!-- Delete the sections that don't apply -->
+
+### Bug fixes
+
+- Pass in session as a keyword argument to initialization of TAP classes

--- a/src/lsst/rsp/catalog.py
+++ b/src/lsst/rsp/catalog.py
@@ -51,7 +51,7 @@ def get_tap_service(*args: str) -> pyvo.dal.TAPService:
     # 81a50d7fd24428f17104a075bc0e1ac661ed6ea0/pyvo/utils/xml/elements.py#L418
     with warnings.catch_warnings():
         warnings.simplefilter("ignore", category=UserWarning)
-        return pyvo.dal.TAPService(tap_url, get_pyvo_auth())
+        return pyvo.dal.TAPService(tap_url, session=get_pyvo_auth())
 
 
 def retrieve_query(query_url: str) -> pyvo.dal.AsyncTAPJob:
@@ -65,4 +65,4 @@ def retrieve_query(query_url: str) -> pyvo.dal.AsyncTAPJob:
     # 81a50d7fd24428f17104a075bc0e1ac661ed6ea0/pyvo/utils/xml/elements.py#L418
     with warnings.catch_warnings():
         warnings.simplefilter("ignore", category=UserWarning)
-        return pyvo.dal.AsyncTAPJob(query_url, get_pyvo_auth())
+        return pyvo.dal.AsyncTAPJob(query_url, session=get_pyvo_auth())


### PR DESCRIPTION
Newer version of pyvo requires session to be passed in as a keyword argument