### PR TITLE
DM-49626: Modify get_siav2_service to work with new SIA endpoint

### DIFF
--- a/changelog.d/20250402_191136_steliosvoutsinas_DM_49626.md
+++ b/changelog.d/20250402_191136_steliosvoutsinas_DM_49626.md
@@ -1,0 +1,5 @@
+<!-- Delete the sections that don't apply -->
+
+### Other changes
+
+- Changed get_siav2_service to work with new SIA app and added data_release parameter to it

--- a/src/lsst/rsp/service.py
+++ b/src/lsst/rsp/service.py
@@ -1,5 +1,7 @@
 """Utility functions for IVOA clients."""
 
+import os
+
 from pyvo.dal import SIA2Service
 from pyvo.dal.adhoc import DatalinkResults
 from pyvo.dal.sia2 import ObsCoreRecord
@@ -14,11 +16,29 @@ def get_datalink_result(result: ObsCoreRecord) -> DatalinkResults:
     )
 
 
-def get_siav2_service(label: str) -> SIA2Service:
+def get_siav2_service(data_release: str) -> SIA2Service:
     """Construct an `SIA2Service` client."""
-    if label != "staff":
-        raise ValueError(label + " data not available at your location")
+    # data_release determines the Data release, as we may have different
+    # releases being served from the same server.
 
-    # No matter what, we've only got one sia server per environment
-    # so for now just do some checking.
-    return SIA2Service(get_service_url("siav2"), get_pyvo_auth())
+    label = os.getenv("RSP_SITE_TYPE", None)
+
+    # The label variable here corresponds to RSP "kind" (i.e. "telescope",
+    # "science", "staff")
+
+    if label not in {"science", "staff"}:
+        if label is None:
+            raise ValueError("RSP_SITE_TYPE environment variable is not set")
+        raise ValueError(f"{label} data not available at your location")
+
+    sia_url = get_service_url(f"sia/{data_release}")
+    if not sia_url:
+        raise RuntimeError(
+            f"Failed to determine service URL for data release: {data_release}"
+        )
+
+    session = get_pyvo_auth()
+    if session:
+        session.add_security_method_for_url(sia_url + "/query", "lsst-token")
+
+    return SIA2Service(sia_url, session=session)

--- a/src/lsst/rsp/utils.py
+++ b/src/lsst/rsp/utils.py
@@ -81,7 +81,7 @@ def get_pyvo_auth() -> pyvo.auth.authsession.AuthSession | None:
         "ssotap": get_service_url("ssotap"),
         "consdbtap": get_service_url("consdbtap"),
         "live": get_service_url("live"),
-        "siav2": get_service_url("siav2"),
+        "sia": get_service_url("sia"),
         "cutout": get_service_url("cutout"),
         "datalink": get_service_url("datalink"),
     }
@@ -93,9 +93,6 @@ def get_pyvo_auth() -> pyvo.auth.authsession.AuthSession | None:
         if name in ["tap", "obstap", "ssotap", "consdbtap", "live"]:
             for subpath in ["/sync", "/async", "/tables"]:
                 auth.add_security_method_for_url(url + subpath, "lsst-token")
-
-        elif name == "siav2":
-            auth.add_security_method_for_url(url + "/query", "lsst-token")
 
     return auth
 


### PR DESCRIPTION
## Summary

Updates the `get_siav2_service` method to support the new SIA endpoints.
These are now found under:
`/api/sia/dp02/`

I added a call to `add_security_method_for_url` inside `get_siav2_service` because it needs to include the label (data release).
The only other alternative I saw for this to work is to maintain a list of data releases and have the utils `get_pyvo_auth` add an auth url for each