### PR TITLE
DM-49741: Add consdbtap to pyvo authentication & small refactoring of get_pyvo_auth

### DIFF
--- a/changelog.d/20250327_020729_steliosvoutsinas_DM_49741.md
+++ b/changelog.d/20250327_020729_steliosvoutsinas_DM_49741.md
@@ -1,0 +1,5 @@
+<!-- Delete the sections that don't apply -->
+
+### Bug fixes
+
+- Added consdbtap to list of TAP services that we add the lsst-token authentication method for in pyvo

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 # https://packaging.python.org/en/latest/specifications/declaring-project-metadata/
 name = "lsst-rsp"
 description = "Utility functions for the Rubin Science Platform"
-license = "MIT"
+license = { text = "MIT"}
 readme= "README.md"
 keywords = [
     "rubin",


### PR DESCRIPTION
PR adds `consdbtap` to the list of TAP services for which we add the `lsst-token `authentication method.
It also slightly refactors the `get_pyvo_auth` to move `add_security_method_for_url` call for each subpath of every tap service to a loop.