### PR TITLE
tickets/DM-50484: make debug logging work again

### DIFF
--- a/changelog.d/20250424_143836_athornton_DM_50484.md
+++ b/changelog.d/20250424_143836_athornton_DM_50484.md
@@ -1,0 +1,5 @@
+<!-- Delete the sections that don't apply -->
+
+### Bug fixes
+
+- Debug mode was not working correctly because it invoked a subshell


### PR DESCRIPTION
Spawning the Lab in a subshell rather than with an exec was breaking emission of debug logs.  Since we are 2py now, utterly failing to start the lab should be a much rarer event, so we always exec Jupyterlab now rather than running it in a subshell.