### PR TITLE
DM-54998: Remove import DatasetNotSupportedError that no longer exists

### DIFF
--- a/changelog.d/20260519_212923_steliosvoutsinas_DM_54998.md
+++ b/changelog.d/20260519_212923_steliosvoutsinas_DM_54998.md
@@ -1,0 +1,5 @@
+<!-- Delete the sections that don't apply -->
+
+### Bug fixes
+
+- Remove import DatasetNotSupportedError that no longer exists

--- a/src/lsst/rsp/__init__.py
+++ b/src/lsst/rsp/__init__.py
@@ -39,7 +39,6 @@ from .utils import (
 )
 
 __all__ = [
-    "DatasetNotSupportedError",
     "DiscoveryNotAvailableError",
     "IPythonHandler",
     "InfluxDBCredentials",


### PR DESCRIPTION
Addresses JIRA issue: https://rubinobs.atlassian.net/browse/DM-54998 to remove import for exception that was removed and no longer exists
