### PR TITLE
DM-55158: Send authentication to version URLs

### DIFF
--- a/changelog.d/20260604_162449_rra_DM_55158.md
+++ b/changelog.d/20260604_162449_rra_DM_55158.md
@@ -1,0 +1,3 @@
+### Bug fixes
+
+- Send authentication credentials to all URLs in the versions list for services, not only the base URL. This, in conjunction with updated service discovery information, will fix a failure to send authentication to the TAP tables endpoint via PyVO's TAP client.

--- a/src/lsst/rsp/_services.py
+++ b/src/lsst/rsp/_services.py
@@ -353,11 +353,19 @@ class RSPDiscovery:
         return f"lsst-rsp/{__version__} {user_agent}".strip()
 
     def _get_all_service_urls(self) -> set[str]:
-        """Return all service URLs for the configured dataset."""
+        """Return all service URLs for the configured dataset.
+
+        This is used to configure the URLs for which requests or PyVO should
+        send credentials.
+        """
         urls = set()
         for service in self._discovery.get("services", {}).values():
             if url := service.get("url"):
                 urls.add(url)
+            if versions := service.get("versions"):
+                for version in versions.values():
+                    if url := version.get("url"):
+                        urls.add(url)
         return urls
 
     def _get_pyvo_auth(self) -> AuthSession:

--- a/tests/data/discovery/v1.json
+++ b/tests/data/discovery/v1.json
@@ -44,7 +44,7 @@
       "butler_config": "https://data.example.com/api/butler/repo/dp1/butler.yaml",
       "services": {
         "cutout": {
-          "url": "https://data.example.com/api/cutout",
+          "url": "https://data.example.com/api/cutouts",
           "versions": {
             "soda-async-1.0": {
               "url": "https://data.example.com/api/cutout/dp1/jobs"

--- a/tests/services_test.py
+++ b/tests/services_test.py
@@ -81,6 +81,18 @@ def test_get_session(token: str, requests_mock: Mocker) -> None:
     assert r.status_code == 200
     assert r.text == "okay"
 
+    # Check the same for a URL under one of the versions.
+    url = services.get_service_url("cutout", version="soda-sync-1.0")
+    requests_mock.get(
+        url,
+        additional_matcher=_has_lsst_rsp_user_agent,
+        request_headers={"Authorization": f"Bearer {token}"},
+        text="okay",
+    )
+    r = session.get(url)
+    assert r.status_code == 200
+    assert r.text == "okay"
+
     def no_token(request: Any) -> bool:
         return "Authorization" not in request.headers
 


### PR DESCRIPTION
Send authentication credentials to all URLs in the versions list for services, not only the base URL. This, in conjunction with updated service discovery information, will fix a failure to send authentication to the TAP tables endpoint via PyVO's TAP client.

Update the test discovery data so that the API versions for cutout aren't beneath the base URL so that this behavior is tested.