### PR TITLE
DM-55165: Ignore query strings and fragments for sending auth

### DIFF
--- a/changelog.d/20260605_111810_rra_DM_55165.md
+++ b/changelog.d/20260605_111810_rra_DM_55165.md
@@ -1,0 +1,3 @@
+### Bug fixes
+
+- When determining whether to send authentication credentials to a URL in the requests session returned by `get_session`, ignore query strings and fragments.

--- a/src/lsst/rsp/_services.py
+++ b/src/lsst/rsp/_services.py
@@ -5,6 +5,7 @@ import os
 from contextlib import suppress
 from pathlib import Path
 from typing import Any, ClassVar, override
+from urllib.parse import urlparse, urlunparse
 
 import requests
 from pyvo.auth import AuthSession
@@ -50,7 +51,8 @@ class _RSPAuth(AuthBase):
     def __call__(self, request: PreparedRequest) -> PreparedRequest:
         if not request.url:
             return request
-        if request.url in self._urls or request.url.startswith(self._prefixes):
+        url = urlunparse(urlparse(request.url)._replace(query="", fragment=""))
+        if url in self._urls or url.startswith(self._prefixes):
             request.headers["Authorization"] = f"Bearer {self._token}"
         return request
 

--- a/tests/services_test.py
+++ b/tests/services_test.py
@@ -69,8 +69,22 @@ def test_get_session(token: str, requests_mock: Mocker) -> None:
     session = services.get_session()
 
     # Register a mock under one of the URLs for a service and ensure that the
-    # token is correctly sent.
+    # token is correctly sent. Check with and without query parameters.
     url = services.get_service_url("cutout")
+    requests_mock.get(
+        url,
+        additional_matcher=_has_lsst_rsp_user_agent,
+        request_headers={"Authorization": f"Bearer {token}"},
+        text="okay",
+    )
+    r = session.get(url)
+    assert r.status_code == 200
+    assert r.text == "okay"
+    r = session.get(url, params={"query": "something"})
+    assert r.status_code == 200
+    assert r.text == "okay"
+
+    # The token should also be sent to a child URL of that URL.
     requests_mock.get(
         url + "/jobs",
         additional_matcher=_has_lsst_rsp_user_agent,
@@ -81,7 +95,10 @@ def test_get_session(token: str, requests_mock: Mocker) -> None:
     assert r.status_code == 200
     assert r.text == "okay"
 
-    # Check the same for a URL under one of the versions.
+    # Check the same for a URL under one of the versions. The test discovery
+    # data puts these versions under a different URL prefix as the base URL
+    # for the service so that this test can verify that version URLs are
+    # registered separately.
     url = services.get_service_url("cutout", version="soda-sync-1.0")
     requests_mock.get(
         url,


### PR DESCRIPTION
When determining whether to send authentication tokens to a URL in a service-discovery-created requests session, ignore query strings and fragments.