### PR TITLE
DM-55165: Support the local flag in InfluxDB databases

### DIFF
--- a/changelog.d/20260608_171642_rra_DM_55165.md
+++ b/changelog.d/20260608_171642_rra_DM_55165.md
@@ -1,0 +1,3 @@
+### New features
+
+- Add new parameter, `local`, to `list_influxdb_labels`, allowing the caller to request only the local or only the remote InfluxDB databases.

--- a/src/lsst/rsp/_discovery.py
+++ b/src/lsst/rsp/_discovery.py
@@ -274,12 +274,19 @@ def list_datasets(*, discovery_v1_path: Path | None = None) -> list[str]:
 
 
 def list_influxdb_labels(
-    *, discovery_v1_path: Path | None = None
+    *, local: bool | None = None, discovery_v1_path: Path | None = None
 ) -> list[str]:
     """List the available InfluxDB labels in this environment.
 
     Parameters
     ----------
+    local
+        If set to `True`, return only InfluxDB databases hosted in the local
+        Phalanx environment (the one whose service discovery service is being
+        queried). If set to `False`, return only InfluxDB databases that are
+        hosted outside this Phalanx environment. The default, `None`, lists
+        all accessible databases, local or not. This parameter is primarily
+        for testing and should normally not be provided.
     discovery_v1_path
         Path to discovery information. This is intended for testing and should
         normally not be provided. The default is the expected path to
@@ -299,4 +306,11 @@ def list_influxdb_labels(
     if not discovery_v1_path:
         discovery_v1_path = _DISCOVERY_PATH
     discovery = _get_discovery(discovery_v1_path)
-    return sorted(discovery.get("influxdb_databases", {}).keys())
+    if local is None:
+        return sorted(discovery.get("influxdb_databases", {}).keys())
+    else:
+        databases = discovery.get("influxdb_databases", {}).items()
+        if local:
+            return sorted(k for k, v in databases if v.get("local"))
+        else:
+            return sorted(k for k, v in databases if not v.get("local"))

--- a/tests/data/discovery/full.json
+++ b/tests/data/discovery/full.json
@@ -30,6 +30,14 @@
     "idfdev_efd": {
       "url": "https://data.example.com/influxdb/",
       "database": "efd",
+      "local": false,
+      "schema_registry": "http://sasquatch-schema-registry.sasquatch:8081/",
+      "credentials_url": "https://example.com/repertoire/discovery/influxdb/idfdev_efd"
+    },
+    "idfdev_metrics": {
+      "url": "https://data.example.com/influxdb/",
+      "database": "efd",
+      "local": true,
       "schema_registry": "http://sasquatch-schema-registry.sasquatch:8081/",
       "credentials_url": "https://example.com/repertoire/discovery/influxdb/idfdev_efd"
     }

--- a/tests/data/discovery/v1.json
+++ b/tests/data/discovery/v1.json
@@ -75,6 +75,7 @@
     "idfdev_metrics": {
       "url": "https://data.example.com/influxdb/",
       "database": "lsst.square.metrics",
+      "local": true,
       "schema_registry": "http://sasquatch-schema-registry.sasquatch:8081/",
       "credentials_url": "https://example.com/repertoire/discovery/influxdb/idfdev_metrics"
     }

--- a/tests/discovery_test.py
+++ b/tests/discovery_test.py
@@ -120,6 +120,19 @@ def test_list_influxdb_labels(discovery_v1_path: Path) -> None:
 
     assert list_influxdb_labels(discovery_v1_path=discovery_v1_path) == labels
 
+    databases = discovery["influxdb_databases"].items()
+    local = sorted(k for k, v in databases if v.get("local"))
+    remote = sorted(k for k, v in databases if not v.get("local"))
+
+    assert (
+        list_influxdb_labels(local=True, discovery_v1_path=discovery_v1_path)
+        == local
+    )
+    assert (
+        list_influxdb_labels(local=False, discovery_v1_path=discovery_v1_path)
+        == remote
+    )
+
 
 def test_missing_discovery() -> None:
     with patch.object(_discovery, "_DISCOVERY_PATH", new=Path("/nonexistent")):


### PR DESCRIPTION
Add a new parameter, `local`, to `list_influxdb_labels`, allowing the caller to request only the local or only the remote InfluxDB labels. This is primarily for internal use, such as finding the local Sasquatch InfluxDB service for health checks.