### PR TITLE
DM-55165: Drop discovery_v1_path arguments

### DIFF
--- a/changelog.d/20260608_174725_rra_DM_55165a.md
+++ b/changelog.d/20260608_174725_rra_DM_55165a.md
@@ -1,0 +1,3 @@
+### Backwards-incompatible changes
+
+- Drop `discovery_v1_path` as an optional argument from all discovery functions. This was only used for testing.

--- a/src/lsst/rsp/_discovery.py
+++ b/src/lsst/rsp/_discovery.py
@@ -65,13 +65,8 @@ class InfluxDBCredentials(InfluxDBLocation):
     """Password to use for authentication."""
 
 
-def _get_discovery(path: Path) -> dict[str, Any]:
+def _get_discovery() -> dict[str, Any]:
     """Get the data and service discovery information.
-
-    Parameters
-    ----------
-    path
-        Path to discovery information.
 
     Returns
     -------
@@ -84,7 +79,7 @@ def _get_discovery(path: Path) -> dict[str, Any]:
         Raised if no service discovery information is available.
     """
     try:
-        return json.loads(path.read_text())
+        return json.loads(_DISCOVERY_PATH.read_text())
     except FileNotFoundError as e:
         raise DiscoveryNotAvailableError(e) from e
 
@@ -92,8 +87,6 @@ def _get_discovery(path: Path) -> dict[str, Any]:
 def get_influxdb_credentials(
     label: str,
     token: str | None = None,
-    *,
-    discovery_v1_path: Path | None = None,
 ) -> InfluxDBCredentials:
     """Get the credentials for an InfluxDB database.
 
@@ -104,10 +97,6 @@ def get_influxdb_credentials(
     token
         If given, use this Gafaelfawr token instead of the local notebook
         token.
-    discovery_v1_path
-        Path to discovery information. This is intended for testing and should
-        normally not be provided. The default is the expected path to
-        discovery information within a Nublado notebook.
 
     Returns
     -------
@@ -125,9 +114,7 @@ def get_influxdb_credentials(
     UnknownInfluxDBError
         Raised if the InfluxDB database is not known.
     """
-    if not discovery_v1_path:
-        discovery_v1_path = _DISCOVERY_PATH
-    discovery = _get_discovery(discovery_v1_path)
+    discovery = _get_discovery()
     influxdb = discovery.get("influxdb_databases", {}).get(label)
     if not influxdb:
         raise UnknownInfluxDBError(label)
@@ -160,19 +147,13 @@ def get_influxdb_credentials(
         raise InvalidDiscoveryError(e, f"InfluxDB creds for {label}") from e
 
 
-def get_influxdb_location(
-    label: str, *, discovery_v1_path: Path | None = None
-) -> InfluxDBLocation:
+def get_influxdb_location(label: str) -> InfluxDBLocation:
     """Get the location information for an InfluxDB database.
 
     Parameters
     ----------
     label
         Human label for the InfluxDB database.
-    discovery_v1_path
-        Path to discovery information. This is intended for testing and should
-        normally not be provided. The default is the expected path to
-        discovery information within a Nublado notebook.
 
     Returns
     -------
@@ -188,9 +169,7 @@ def get_influxdb_location(
     UnknownInfluxDBError
         Raised if the InfluxDB database is not known.
     """
-    if not discovery_v1_path:
-        discovery_v1_path = _DISCOVERY_PATH
-    discovery = _get_discovery(discovery_v1_path)
+    discovery = _get_discovery()
     influxdb = discovery.get("influxdb_databases", {}).get(label)
     if not influxdb:
         raise UnknownInfluxDBError(label)
@@ -204,9 +183,7 @@ def get_influxdb_location(
         raise InvalidDiscoveryError(e, f"InfluxDB database {label}") from e
 
 
-def get_service_url(
-    service: str, dataset: str, *, discovery_v1_path: Path | None = None
-) -> str:
+def get_service_url(service: str, dataset: str) -> str:
     """Get the API URL for a service and dataset combination.
 
     Parameters
@@ -215,10 +192,6 @@ def get_service_url(
         Name of the service.
     dataset
         Name of the dataset.
-    discovery_v1_path
-        Path to discovery information. This is intended for testing and should
-        normally not be provided. The default is the expected path to
-        discovery information within a Nublado notebook.
 
     Returns
     -------
@@ -235,9 +208,7 @@ def get_service_url(
         Raised if this service is not present in the environment for this
         dataset.
     """
-    if not discovery_v1_path:
-        discovery_v1_path = _DISCOVERY_PATH
-    discovery = _get_discovery(discovery_v1_path)
+    discovery = _get_discovery()
     dataset_info = discovery.get("datasets", {}).get(dataset)
     if not dataset_info:
         raise UnknownDatasetError(dataset)
@@ -247,15 +218,8 @@ def get_service_url(
     return url
 
 
-def list_datasets(*, discovery_v1_path: Path | None = None) -> list[str]:
+def list_datasets() -> list[str]:
     """List the available datasets in this environment.
-
-    Parameters
-    ----------
-    discovery_v1_path
-        Path to discovery information. This is intended for testing and should
-        normally not be provided. The default is the expected path to
-        discovery information within a Nublado notebook.
 
     Returns
     -------
@@ -267,15 +231,11 @@ def list_datasets(*, discovery_v1_path: Path | None = None) -> list[str]:
     DiscoveryNotAvailableError
         Raised if no service discovery information is available.
     """
-    if not discovery_v1_path:
-        discovery_v1_path = _DISCOVERY_PATH
-    discovery = _get_discovery(discovery_v1_path)
+    discovery = _get_discovery()
     return sorted(discovery.get("datasets", {}).keys())
 
 
-def list_influxdb_labels(
-    *, local: bool | None = None, discovery_v1_path: Path | None = None
-) -> list[str]:
+def list_influxdb_labels(*, local: bool | None = None) -> list[str]:
     """List the available InfluxDB labels in this environment.
 
     Parameters
@@ -287,10 +247,6 @@ def list_influxdb_labels(
         hosted outside this Phalanx environment. The default, `None`, lists
         all accessible databases, local or not. This parameter is primarily
         for testing and should normally not be provided.
-    discovery_v1_path
-        Path to discovery information. This is intended for testing and should
-        normally not be provided. The default is the expected path to
-        discovery information within a Nublado notebook.
 
     Returns
     -------
@@ -303,9 +259,7 @@ def list_influxdb_labels(
     DiscoveryNotAvailableError
         Raised if no service discovery information is available.
     """
-    if not discovery_v1_path:
-        discovery_v1_path = _DISCOVERY_PATH
-    discovery = _get_discovery(discovery_v1_path)
+    discovery = _get_discovery()
     if local is None:
         return sorted(discovery.get("influxdb_databases", {}).keys())
     else:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -24,12 +24,6 @@ def discovery_path(data: Data, fs: FakeFilesystem) -> Path:
 
 
 @pytest.fixture
-def discovery_v1_path() -> Path:
-    """Delete once older functions and tests are retired."""
-    return Path(__file__).parent / "data" / "discovery" / "v1.json"
-
-
-@pytest.fixture
 def token(monkeypatch: pytest.MonkeyPatch) -> str:
     monkeypatch.setenv("NUBLADO_TOKEN", "some-token")
     return "some-token"

--- a/tests/discovery_test.py
+++ b/tests/discovery_test.py
@@ -9,6 +9,7 @@ from unittest.mock import patch
 import pytest
 import respx
 from httpx import Request, Response
+from pyfakefs.fake_filesystem import FakeFilesystem
 from safir.testing.data import Data
 
 from lsst.rsp import (
@@ -25,54 +26,50 @@ from lsst.rsp import (
     list_datasets,
     list_influxdb_labels,
 )
+from lsst.rsp._discovery import _DISCOVERY_PATH
 
 
-def test_get_service_url(discovery_v1_path: Path) -> None:
-    discovery = json.loads(discovery_v1_path.read_text())
+def test_get_service_url(discovery_path: Path) -> None:
+    discovery = json.loads(discovery_path.read_text())
 
     expected = discovery["datasets"]["dp1"]["services"]["sia"]["url"]
-    result = get_service_url("sia", "dp1", discovery_v1_path=discovery_v1_path)
+    result = get_service_url("sia", "dp1")
     assert result == expected
     expected = discovery["datasets"]["dp02"]["services"]["cutout"]["url"]
-    result = get_service_url(
-        "cutout", "dp02", discovery_v1_path=discovery_v1_path
-    )
+    result = get_service_url("cutout", "dp02")
     assert result == expected
 
     with pytest.raises(UnknownServiceError):
-        get_service_url("sia", "dp03", discovery_v1_path=discovery_v1_path)
+        get_service_url("sia", "dp03")
 
     with pytest.raises(UnknownDatasetError):
-        get_service_url(
-            "cutout", "unknown", discovery_v1_path=discovery_v1_path
-        )
+        get_service_url("cutout", "unknown")
 
     with pytest.raises(UnknownServiceError):
-        get_service_url("foo", "dp1", discovery_v1_path=discovery_v1_path)
+        get_service_url("foo", "dp1")
 
 
-def test_get_influxdb_location(discovery_v1_path: Path) -> None:
-    discovery = json.loads(discovery_v1_path.read_text())
+def test_get_influxdb_location(discovery_path: Path) -> None:
+    discovery = json.loads(discovery_path.read_text())
 
     expected = discovery["influxdb_databases"]["idfdev_efd"]
-    location = get_influxdb_location(
-        "idfdev_efd", discovery_v1_path=discovery_v1_path
-    )
+    location = get_influxdb_location("idfdev_efd")
     assert location.url == expected["url"]
     assert location.database == expected["database"]
     assert location.schema_registry == expected["schema_registry"]
 
     with pytest.raises(UnknownInfluxDBError):
-        get_influxdb_location("unknown", discovery_v1_path=discovery_v1_path)
+        get_influxdb_location("unknown")
 
 
 def test_get_influxdb_credentials(
+    *,
     data: Data,
-    discovery_v1_path: Path,
+    discovery_path: Path,
     respx_mock: respx.Router,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    discovery = json.loads(discovery_v1_path.read_text())
+    discovery = json.loads(discovery_path.read_text())
     efd_data = discovery["influxdb_databases"]["idfdev_efd"]
     credentials_url = efd_data["credentials_url"]
 
@@ -83,13 +80,9 @@ def test_get_influxdb_credentials(
     respx_mock.get(credentials_url).mock(side_effect=handler)
 
     with pytest.raises(TokenNotAvailableError):
-        get_influxdb_credentials(
-            "idfdev_efd", discovery_v1_path=discovery_v1_path
-        )
+        get_influxdb_credentials("idfdev_efd")
 
-    credentials = get_influxdb_credentials(
-        "idfdev_efd", "some-token", discovery_v1_path=discovery_v1_path
-    )
+    credentials = get_influxdb_credentials("idfdev_efd", "some-token")
     expected = data.read_json("discovery/idfdev_efd")
     assert credentials.url == expected["url"]
     assert credentials.database == expected["database"]
@@ -98,40 +91,32 @@ def test_get_influxdb_credentials(
     assert credentials.password == expected["password"]
 
     monkeypatch.setenv("ACCESS_TOKEN", "some-token")
-    result = get_influxdb_credentials(
-        "idfdev_efd", discovery_v1_path=discovery_v1_path
-    )
+    result = get_influxdb_credentials("idfdev_efd")
     assert result == credentials
 
     with pytest.raises(UnknownInfluxDBError):
-        get_influxdb_location("unknown", discovery_v1_path=discovery_v1_path)
+        get_influxdb_location("unknown")
 
 
-def test_list_datasets(discovery_v1_path: Path) -> None:
-    discovery = json.loads(discovery_v1_path.read_text())
+def test_list_datasets(discovery_path: Path) -> None:
+    discovery = json.loads(discovery_path.read_text())
     datasets = sorted(discovery["datasets"].keys())
 
-    assert list_datasets(discovery_v1_path=discovery_v1_path) == datasets
+    assert list_datasets() == datasets
 
 
-def test_list_influxdb_labels(discovery_v1_path: Path) -> None:
-    discovery = json.loads(discovery_v1_path.read_text())
+def test_list_influxdb_labels(discovery_path: Path) -> None:
+    discovery = json.loads(discovery_path.read_text())
     labels = sorted(discovery["influxdb_databases"].keys())
 
-    assert list_influxdb_labels(discovery_v1_path=discovery_v1_path) == labels
+    assert list_influxdb_labels() == labels
 
     databases = discovery["influxdb_databases"].items()
     local = sorted(k for k, v in databases if v.get("local"))
     remote = sorted(k for k, v in databases if not v.get("local"))
 
-    assert (
-        list_influxdb_labels(local=True, discovery_v1_path=discovery_v1_path)
-        == local
-    )
-    assert (
-        list_influxdb_labels(local=False, discovery_v1_path=discovery_v1_path)
-        == remote
-    )
+    assert list_influxdb_labels(local=True) == local
+    assert list_influxdb_labels(local=False) == remote
 
 
 def test_missing_discovery() -> None:
@@ -149,9 +134,14 @@ def test_missing_discovery() -> None:
 
 
 def test_invalid_discovery(
-    data: Data, respx_mock: respx.Router, monkeypatch: pytest.MonkeyPatch
+    *,
+    data: Data,
+    fs: FakeFilesystem,
+    respx_mock: respx.Router,
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     invalid_path = data.path("discovery/v1-invalid.json")
+    fs.add_real_file(invalid_path, target_path=_DISCOVERY_PATH)
     monkeypatch.setenv("ACCESS_TOKEN", "some-token")
 
     def handler(request: Request) -> Response:
@@ -165,20 +155,20 @@ def test_invalid_discovery(
     respx_mock.get(credentials_url).mock(side_effect=handler)
 
     with pytest.raises(UnknownServiceError):
-        get_service_url("cutout", "dp02", discovery_v1_path=invalid_path)
+        get_service_url("cutout", "dp02")
     with pytest.raises(InvalidDiscoveryError):
-        get_influxdb_location("idfdev_efd", discovery_v1_path=invalid_path)
+        get_influxdb_location("idfdev_efd")
     with pytest.raises(InvalidDiscoveryError):
-        get_influxdb_credentials("idfdev_efd", discovery_v1_path=invalid_path)
+        get_influxdb_credentials("idfdev_efd")
 
 
-def test_empty(data: Data) -> None:
+def test_empty(data: Data, fs: FakeFilesystem) -> None:
     empty_path = data.path("discovery/empty.json")
-    with patch.object(_discovery, "_DISCOVERY_PATH", new=empty_path):
-        assert list_influxdb_labels() == []
-        with pytest.raises(UnknownDatasetError):
-            get_service_url("sia", "dp1")
-        with pytest.raises(UnknownInfluxDBError):
-            get_influxdb_location("idfdev_efd")
-        with pytest.raises(UnknownInfluxDBError):
-            get_influxdb_credentials("idfdev_efd")
+    fs.add_real_file(empty_path, target_path=_DISCOVERY_PATH)
+    assert list_influxdb_labels() == []
+    with pytest.raises(UnknownDatasetError):
+        get_service_url("sia", "dp1")
+    with pytest.raises(UnknownInfluxDBError):
+        get_influxdb_location("idfdev_efd")
+    with pytest.raises(UnknownInfluxDBError):
+        get_influxdb_credentials("idfdev_efd")


### PR DESCRIPTION
The `discovery_v1_path` argument to the discovery functions was only used for testing. Convert the tests fully to pyfakefs for discovery information and drop this now-unnecessary argument.